### PR TITLE
Disable compare feature by configuration

### DIFF
--- a/components/core/blocks/Compare/AddToCompare.vue
+++ b/components/core/blocks/Compare/AddToCompare.vue
@@ -1,5 +1,6 @@
 <template>
   <button
+    v-if="isCompareEnabled"
     @click="isOnCompare ? removeProduct(product) : addProduct(product)"
     class="p0 inline-flex middle-xs bg-cl-transparent brdr-none action h5 pointer cl-secondary"
     type="button"
@@ -18,37 +19,38 @@
 </template>
 
 <script>
-import { IsOnCompare } from '@vue-storefront/core/modules/compare/components/IsOnCompare'
-import { AddToCompare } from '@vue-storefront/core/modules/compare/components/AddToCompare'
-import { RemoveFromCompare } from '@vue-storefront/core/modules/compare/components/RemoveFromCompare'
-import i18n from '@vue-storefront/i18n'
-import { htmlDecode } from '@vue-storefront/core/lib/store/filters'
+  import { IsOnCompare } from '@vue-storefront/core/modules/compare/components/IsOnCompare'
+  import { AddToCompare } from '@vue-storefront/core/modules/compare/components/AddToCompare'
+  import { CompareStatus } from '@vue-storefront/core/modules/compare/components/CompareStatus'
+  import { RemoveFromCompare } from '@vue-storefront/core/modules/compare/components/RemoveFromCompare'
+  import i18n from '@vue-storefront/i18n'
+  import { htmlDecode } from '@vue-storefront/core/lib/store/filters'
 
-export default {
-  mixins: [IsOnCompare, AddToCompare, RemoveFromCompare],
-  props: {
-    product: {
-      required: true,
-      type: Object
-    }
-  },
-  methods: {
-    addProduct (product) {
-      this.addToCompare(product)
-      this.$store.dispatch('notification/spawnNotification', {
-        type: 'success',
-        message: i18n.t('Product {productName} has been added to the compare!', { productName: htmlDecode(product.name) }),
-        action1: { label: i18n.t('OK') }
-      }, { root: true })
+  export default {
+    mixins: [IsOnCompare, AddToCompare, RemoveFromCompare, CompareStatus],
+    props: {
+      product: {
+        required: true,
+        type: Object
+      }
     },
-    removeProduct (product) {
-      this.removeFromCompare(product)
-      this.$store.dispatch('notification/spawnNotification', {
-        type: 'success',
-        message: i18n.t('Product {productName} has been removed from compare!', { productName: htmlDecode(product.name) }),
-        action1: { label: i18n.t('OK') }
-      }, { root: true })
+    methods: {
+      addProduct (product) {
+        this.addToCompare(product)
+        this.$store.dispatch('notification/spawnNotification', {
+          type: 'success',
+          message: i18n.t('Product {productName} has been added to the compare!', { productName: htmlDecode(product.name) }),
+          action1: { label: i18n.t('OK') }
+        }, { root: true })
+      },
+      removeProduct (product) {
+        this.removeFromCompare(product)
+        this.$store.dispatch('notification/spawnNotification', {
+          type: 'success',
+          message: i18n.t('Product {productName} has been removed from compare!', { productName: htmlDecode(product.name) }),
+          action1: { label: i18n.t('OK') }
+        }, { root: true })
+      }
     }
   }
-}
 </script>

--- a/components/core/blocks/Compare/ProductAttribute.vue
+++ b/components/core/blocks/Compare/ProductAttribute.vue
@@ -1,11 +1,12 @@
 <template>
-  <span>{{ value|htmlDecode }}</span>
+  <span v-if="isCompareEnabled">{{ value | htmlDecode }}</span>
 </template>
 
 <script>
-import ProductAttribute from '../../ProductAttribute.vue'
+  import ProductAttribute from '../../ProductAttribute.vue'
+  import { CompareStatus } from '@vue-storefront/core/modules/compare/components/CompareStatus'
 
-export default {
-  mixins: [ProductAttribute]
-}
+  export default {
+    mixins: [ProductAttribute, CompareStatus]
+  }
 </script>

--- a/components/core/blocks/Compare/RemoveButton.vue
+++ b/components/core/blocks/Compare/RemoveButton.vue
@@ -1,5 +1,6 @@
 <template>
   <button
+    v-if="isCompareEnabled"
     class="brdr-none bg-cl-transparent p15"
     :aria-label="$t('Remove')"
     :title="$t('Remove')"
@@ -7,3 +8,11 @@
     <i class="material-icons h4">close</i>
   </button>
 </template>
+
+<script>
+  import { CompareStatus } from '@vue-storefront/core/modules/compare/components/CompareStatus'
+
+  export default {
+    mixins: [CompareStatus]
+  }
+</script>

--- a/components/core/blocks/Header/CompareIcon.vue
+++ b/components/core/blocks/Header/CompareIcon.vue
@@ -1,5 +1,10 @@
 <template>
-  <router-link :to="localizedRoute('/compare')" class="compare-icon no-underline inline-flex" v-if="isActive" data-testid="compare-list-icon">
+  <router-link
+    :to="localizedRoute('/compare')"
+    class="compare-icon no-underline inline-flex"
+    v-if="isCompareEnabled && isActive"
+    data-testid="compare-list-icon"
+  >
     <i class="material-icons">compare</i>
     <span
       class="compare-count absolute flex center-xs middle-xs border-box py0 px2 h6 lh16 weight-700 cl-white bg-cl-silver"
@@ -12,15 +17,16 @@
 </template>
 
 <script>
-import CompareIcon from '@vue-storefront/core/compatibility/components/blocks/Header/CompareIcon'
-import { mapGetters } from 'vuex'
+  import CompareIcon from '@vue-storefront/core/compatibility/components/blocks/Header/CompareIcon'
+  import { CompareStatus } from '@vue-storefront/core/modules/compare/components/CompareStatus'
+  import { mapGetters } from 'vuex'
 
-export default {
-  mixins: [CompareIcon],
-  computed: {
-    ...mapGetters('compare', ['getCompareProductsCount'])
+  export default {
+    mixins: [CompareIcon, CompareStatus],
+    computed: {
+      ...mapGetters('compare', ['getCompareProductsCount'])
+    }
   }
-}
 </script>
 
 <style scoped>


### PR DESCRIPTION
### Related Issues
Require https://github.com/DivanteLtd/vue-storefront/pull/4573

### Short Description and Why It's Useful
The new configuration 'compare.enabled' allows to disable the compare feature.
It's useful because this feature does not make sense in all kind of shops.

### Screenshots of Visual Changes before/after
![](https://user-images.githubusercontent.com/11209920/85519748-3d213e00-b602-11ea-8e14-be8dce950290.png)

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-default/blob/master/CONTRIBUTING.md)