### PR TITLE
Fix manageQuantity property type

### DIFF
--- a/pages/Product.vue
+++ b/pages/Product.vue
@@ -404,7 +404,7 @@ export default {
           qty: this.getCurrentProduct.qty
         })
 
-        this.manageQuantity = res.isManageStock
+        this.manageQuantity = !!res.isManageStock
         this.maxQuantity = res.isManageStock ? res.qty : null
       } finally {
         this.isStockInfoLoading = false

--- a/pages/Product.vue
+++ b/pages/Product.vue
@@ -404,7 +404,7 @@ export default {
           qty: this.getCurrentProduct.qty
         })
 
-        this.manageQuantity = !!res.isManageStock
+        this.manageQuantity = Boolean(res.isManageStock)
         this.maxQuantity = res.isManageStock ? res.qty : null
       } finally {
         this.isStockInfoLoading = false

--- a/pages/Product.vue
+++ b/pages/Product.vue
@@ -405,7 +405,7 @@ export default {
         })
 
         this.manageQuantity = Boolean(res.isManageStock)
-        this.maxQuantity = res.isManageStock ? res.qty : null
+        this.maxQuantity = this.manageQuantity ? res.qty : null
       } finally {
         this.isStockInfoLoading = false
       }


### PR DESCRIPTION
### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
In some edge cases, the manageQuantity property is a Number, instead of a Boolean. This causes obviously a render error on the page. To avoid it, I simply convert the returning value from the store always to boolean.

### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-default/blob/master/CONTRIBUTING.md)