### PR TITLE
Bugfix/#25 filter option is not working correctly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.12.2] - UNRELEASED
+
+### Added
+### Changed / Improved
+
+- Added phone number validation in checkout block (#30)
+

--- a/changelog.md
+++ b/changelog.md
@@ -8,7 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.2] - UNRELEASED
 
 ### Added
-### Changed / Improved
-
 - Added phone number validation in checkout block (#30)
+
+### Changed / Improved
+- Fixed closing sidebar after clicking on go to checkout button (#28) 
+
+
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.2] - UNRELEASED
 
 ### Added
+- Added window height helper for scrolling on iOS when filters on Category Page are open (#25)
 - Added phone number validation in checkout block (#30)
 
 ### Changed / Improved

--- a/changelog.md
+++ b/changelog.md
@@ -5,13 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.13] - UNRELEASED
+
+### Added
+- Add vue-lazyload dependency (#36)
+
 ## [1.12.2] - UNRELEASED
 
 ### Added
 - Added phone number validation in checkout block (#30)
 
 ### Changed / Improved
-- Fixed closing sidebar after clicking on go to checkout button (#28) 
-
-
-
+- Fixed closing sidebar after clicking on go to checkout button (#28)

--- a/components/core/blocks/Checkout/Payment.vue
+++ b/components/core/blocks/Checkout/Payment.vue
@@ -190,6 +190,10 @@
               {
                 condition: $v.payment.phoneNumber.$error && !$v.payment.phoneNumber.required,
                 text: $t('Field is required')
+              },
+              {
+                condition: !!payment.phoneNumber && $v.payment.phoneNumber.$error && !$v.payment.phoneNumber.phoneNum,
+                text: $t('Please provide valid phone number')
               }
             ]"
             autocomplete="tel"
@@ -326,7 +330,7 @@
 
 <script>
 import { required, minLength } from 'vuelidate/lib/validators'
-import { unicodeAlpha, unicodeAlphaNum } from '@vue-storefront/core/helpers/validators'
+import { unicodeAlpha, unicodeAlphaNum, phoneNum } from '@vue-storefront/core/helpers/validators'
 import { Payment } from '@vue-storefront/core/modules/checkout/components/Payment'
 
 import BaseCheckbox from 'theme/components/core/blocks/Form/BaseCheckbox'
@@ -371,7 +375,8 @@ export default {
             required
           },
           phoneNumber: {
-            required
+            required,
+            phoneNum
           },
           streetAddress: {
             required,
@@ -419,7 +424,8 @@ export default {
             required
           },
           phoneNumber: {
-            required
+            required,
+            phoneNum
           },
           streetAddress: {
             required,

--- a/components/core/blocks/Checkout/Shipping.vue
+++ b/components/core/blocks/Checkout/Shipping.vue
@@ -181,6 +181,10 @@
               {
                 condition: $v.shipping.phoneNumber.$error && !$v.shipping.phoneNumber.required,
                 text: $t('Field is required')
+              },
+              {
+                condition: !!shipping.phoneNumber && $v.shipping.phoneNumber.$error && !$v.shipping.phoneNumber.phoneNum,
+                text: $t('Please provide valid phone number')
               }
             ]"
             autocomplete="tel"
@@ -266,7 +270,7 @@
 
 <script>
 import { required, minLength } from 'vuelidate/lib/validators'
-import { unicodeAlpha, unicodeAlphaNum } from '@vue-storefront/core/helpers/validators'
+import { unicodeAlpha, unicodeAlphaNum, phoneNum } from '@vue-storefront/core/helpers/validators'
 import { Shipping } from '@vue-storefront/core/modules/checkout/components/Shipping'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
 
@@ -313,7 +317,8 @@ export default {
         required
       },
       phoneNumber: {
-        required
+        required, 
+        phoneNum
       },
       streetAddress: {
         required,

--- a/components/core/blocks/Microcart/Microcart.vue
+++ b/components/core/blocks/Microcart/Microcart.vue
@@ -201,9 +201,6 @@ export default {
       this.$store.dispatch('cart/removeCoupon')
       this.addCouponPressed = false
     },
-    toggleMicrocart () {
-      this.$store.dispatch('ui/toggleMicrocart')
-    },
     async setCoupon () {
       const couponApplied = await this.applyCoupon(this.couponCode)
       this.addCouponPressed = false
@@ -217,7 +214,7 @@ export default {
       }
     },
     closeMicrocartExtend () {
-      this.toggleMicrocart()
+      this.$store.commit('ui/setMicrocart', false)
       this.$store.commit('ui/setSidebar', false)
       this.addCouponPressed = false
     },
@@ -239,7 +236,7 @@ export default {
         hasNoTimeout: true
       })
     }
-  }
+  },
 }
 </script>
 

--- a/head.js
+++ b/head.js
@@ -32,7 +32,6 @@ export default {
     {
       src: 'https://cdn.jsdelivr.net/npm/pwacompat@2.0.17/pwacompat.min.js',
       async: true,
-      integrity: 'sha384-GOaSLecPIMCJksN83HLuYf9FToOiQ2Df0+0ntv7ey8zjUHESXhthwvq9hXAZTifA',
       crossorigin: 'anonymous'
     }
   ],

--- a/head.js
+++ b/head.js
@@ -30,7 +30,7 @@ export default {
   ],
   script: [
     {
-      src: 'https://cdn.jsdelivr.net/npm/pwacompat@2.0.6/pwacompat.min.js',
+      src: 'https://cdn.jsdelivr.net/npm/pwacompat@2.0.17/pwacompat.min.js',
       async: true,
       integrity: 'sha384-GOaSLecPIMCJksN83HLuYf9FToOiQ2Df0+0ntv7ey8zjUHESXhthwvq9hXAZTifA',
       crossorigin: 'anonymous'

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -1,5 +1,7 @@
+import Vue from 'vue'
 import config from 'config'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+import { isServer } from '@vue-storefront/core/helpers'
 
 export function getPathForStaticPage (path: string) {
   const { storeCode } = currentStoreView()
@@ -7,3 +9,9 @@ export function getPathForStaticPage (path: string) {
 
   return isStoreCodeEquals ? `/i${path}` : path
 }
+
+export const windowHelper = Vue.observable({
+  height: 0
+})
+
+!isServer && window.addEventListener('resize', () => { windowHelper.height = window.innerHeight })

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import App from './App.vue'
 import routes from './router'
 import Vue from 'vue'
 import VueProgressBar from 'vue-progressbar'
+import VueLazyload from 'vue-lazyload'
 import '@vue-storefront/core/lib/passive-listeners'
 import { once } from '@vue-storefront/core/helpers'
 import { module as cartModule } from './store/cart'
@@ -15,6 +16,7 @@ import { StorageManager } from '@vue-storefront/core/lib/storage-manager'
 
 once('__VUE_EXTEND_DROPPOINT_VPB__', () => {
   Vue.use(VueProgressBar)
+  Vue.use(VueLazyload, { attempt: 2, preLoad: 1.5 })
 })
 
 const themeEntry = App

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "@vue-storefront/theme-default",
+  "version": "1.12.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "vue-lazyload": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/vue-lazyload/-/vue-lazyload-1.3.3.tgz",
+      "integrity": "sha512-uHnq0FTEeNmqnbBC2aRKlmtd9LofMZ6Q3mWvgfLa+i9vhxU8fDK+nGs9c1iVT85axSua/AUnMttIq3xPaU9G3A=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bodybuilder": "2.2.21",
     "vue": "^2.6.11",
     "vue-carousel": "^0.18",
+    "vue-lazyload": "^1.3.3",
     "vue-no-ssr": "^0.2.2",
     "vue-progressbar": "^0.7.5",
     "vuelidate": "^0.7.5",

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -42,7 +42,12 @@
         <div class="col-md-3 start-xs category-filters">
           <sidebar :filters="getAvailableFilters" @changeFilter="changeFilter" />
         </div>
-        <div class="col-md-3 start-xs mobile-filters" v-show="mobileFilters">
+        <div
+          class="col-md-3 start-xs mobile-filters"
+          v-show="mobileFilters"
+          ref="mobileFilters"
+          :style="mobileFilters ? { 'max-height': `${windowHelper}px` } : {}"
+        >
           <div class="close-container absolute w-100">
             <i class="material-icons p15 close cl-accent" @click="closeFilters">close</i>
           </div>
@@ -85,6 +90,7 @@ import Breadcrumbs from '../components/core/Breadcrumbs.vue'
 import SortBy from '../components/core/SortBy.vue'
 import { isServer } from '@vue-storefront/core/helpers'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { windowHelper } from 'theme/helpers'
 import { getSearchOptionsFromRouteParams } from '@vue-storefront/core/modules/catalog-next/helpers/categoryHelpers'
 import config from 'config'
 import Columns from '../components/core/Columns.vue'
@@ -95,6 +101,7 @@ import rootStore from '@vue-storefront/core/store';
 import { catalogHooksExecutors } from '@vue-storefront/core/modules/catalog-next/hooks'
 import { localizedRoute, currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { htmlDecode } from '@vue-storefront/core/filters'
+import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 const THEME_PAGE_SIZE = 50
 
@@ -133,6 +140,12 @@ export default {
       loading: true
     }
   },
+  watch: {
+    mobileFilters (value) {
+      if (value) disableBodyScroll(this.$refs.mobileFilters)
+      else clearAllBodyScrollLocks()
+    }
+  },
   computed: {
     ...mapGetters({
       getCurrentSearchQuery: 'category-next/getCurrentSearchQuery',
@@ -146,6 +159,9 @@ export default {
     },
     isCategoryEmpty () {
       return this.getCategoryProductsTotal === 0
+    },
+    windowHelper () {
+      return windowHelper.height
     }
   },
   async asyncData ({ store, route, context }) { // this is for SSR purposes to prefetch data - and it's always executed before parent component methods


### PR DESCRIPTION
### Related Issues

Closes #25 

### Short Description and Why It's Useful
I have fixed an issue related to scrolling on iOS devices by adding a new helper `windowHelper`. This helper was created for dynamic window height calculation (especially for iOS devices). Now you shouldn't have any problems when filters are open. Also, I have added `disableBodyScroll` to the `mobileFilters` container to preventing double scrolling.

### Screenshots of Visual Changes before/after (If There Are Any)
#### Before
https://user-images.githubusercontent.com/57936972/88162872-2de9dc00-cc12-11ea-86e1-85fe9faa00d9.gif
#### After
![ezgif com-gif-maker](https://user-images.githubusercontent.com/40273258/98442919-4cfc7300-2108-11eb-9742-215ebfc8c90a.gif)



### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-default/blob/master/CONTRIBUTING.md)