### PR TITLE
Bugfix/#25 filter option is not working correctly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.2] - UNRELEASED
 
 ### Added
+- Added window height helper for scrolling on iOS when filters on Category Page are open (#25)
 - Added phone number validation in checkout block (#30)
 
 ### Changed / Improved

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -1,5 +1,7 @@
+import Vue from 'vue'
 import config from 'config'
 import { currentStoreView } from '@vue-storefront/core/lib/multistore'
+import { isServer } from '@vue-storefront/core/helpers'
 
 export function getPathForStaticPage (path: string) {
   const { storeCode } = currentStoreView()
@@ -7,3 +9,9 @@ export function getPathForStaticPage (path: string) {
 
   return isStoreCodeEquals ? `/i${path}` : path
 }
+
+export const windowHelper = Vue.observable({
+  height: 0
+})
+
+!isServer && window.addEventListener('resize', () => { windowHelper.height = window.innerHeight })

--- a/pages/Category.vue
+++ b/pages/Category.vue
@@ -42,7 +42,12 @@
         <div class="col-md-3 start-xs category-filters">
           <sidebar :filters="getAvailableFilters" @changeFilter="changeFilter" />
         </div>
-        <div class="col-md-3 start-xs mobile-filters" v-show="mobileFilters">
+        <div
+          class="col-md-3 start-xs mobile-filters"
+          v-show="mobileFilters"
+          ref="mobileFilters"
+          :style="mobileFilters ? { 'max-height': `${windowHelper}px` } : {}"
+        >
           <div class="close-container absolute w-100">
             <i class="material-icons p15 close cl-accent" @click="closeFilters">close</i>
           </div>
@@ -85,6 +90,7 @@ import Breadcrumbs from '../components/core/Breadcrumbs.vue'
 import SortBy from '../components/core/SortBy.vue'
 import { isServer } from '@vue-storefront/core/helpers'
 import { Logger } from '@vue-storefront/core/lib/logger'
+import { windowHelper } from 'theme/helpers'
 import { getSearchOptionsFromRouteParams } from '@vue-storefront/core/modules/catalog-next/helpers/categoryHelpers'
 import config from 'config'
 import Columns from '../components/core/Columns.vue'
@@ -95,6 +101,7 @@ import rootStore from '@vue-storefront/core/store';
 import { catalogHooksExecutors } from '@vue-storefront/core/modules/catalog-next/hooks'
 import { localizedRoute, currentStoreView } from '@vue-storefront/core/lib/multistore'
 import { htmlDecode } from '@vue-storefront/core/filters'
+import { disableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock'
 
 const THEME_PAGE_SIZE = 50
 
@@ -133,6 +140,12 @@ export default {
       loading: true
     }
   },
+  watch: {
+    mobileFilters (value) {
+      if (value) disableBodyScroll(this.$refs.mobileFilters)
+      else clearAllBodyScrollLocks()
+    }
+  },
   computed: {
     ...mapGetters({
       getCurrentSearchQuery: 'category-next/getCurrentSearchQuery',
@@ -146,6 +159,9 @@ export default {
     },
     isCategoryEmpty () {
       return this.getCategoryProductsTotal === 0
+    },
+    windowHelper () {
+      return windowHelper.height
     }
   },
   async asyncData ({ store, route, context }) { // this is for SSR purposes to prefetch data - and it's always executed before parent component methods


### PR DESCRIPTION
### Related Issues

Closes #25 

### Short Description and Why It's Useful
I have fixed an issue related to scrolling on iOS devices by adding a new helper `windowHelper`. This helper was created for dynamic window height calculation (especially for iOS devices). Now you shouldn't have any problems when filters are open. Also, I have added `disableBodyScroll` to the `mobileFilters` container to preventing double scrolling.

### Screenshots of Visual Changes before/after (If There Are Any)
#### Before
https://user-images.githubusercontent.com/57936972/88162872-2de9dc00-cc12-11ea-86e1-85fe9faa00d9.gif
#### After
![ezgif com-gif-maker](https://user-images.githubusercontent.com/40273258/98442919-4cfc7300-2108-11eb-9742-215ebfc8c90a.gif)



### Contribution and Currently Important Rules Acceptance
- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-default/blob/master/CONTRIBUTING.md)