### PR TITLE
Bugfix/#24 side swipe sort by

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.2] - UNRELEASED
 
 ### Added
-- Fixed side swiping after selecting 'sort by'
+- Fixed side swiping after selecting 'sort by' (#24)
 - Added window height helper for scrolling on iOS when filters on Category Page are open (#25)
 - Added phone number validation in checkout block (#30)
 

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.12.2] - UNRELEASED
 
 ### Added
+- Fixed side swiping after selecting 'sort by'
 - Added window height helper for scrolling on iOS when filters on Category Page are open (#25)
 - Added phone number validation in checkout block (#30)
 

--- a/components/core/SortBy.vue
+++ b/components/core/SortBy.vue
@@ -80,6 +80,9 @@ export default {
     @media (max-width: 770px) {
       .sort-by {
         width: 100%;
+        select {
+          font-size: 16px;
+        }
       }
     }
 </style>


### PR DESCRIPTION
### Related Issues

Closes #24 

### Short Description and Why It's Useful
For iOS minimal `font-size` should be 16px. Previously it was 14px. I have changed it.


### Screenshots of Visual Changes before/after (If There Are Any)

#### Before
https://user-images.githubusercontent.com/57936972/88161465-4d800500-cc10-11ea-9388-1eaf2428ab2f.gif

#### After
![4ly9nf](https://user-images.githubusercontent.com/40273258/98813593-b2ac7000-2424-11eb-8611-4e41f1b2c1dc.gif)

### Contribution and Currently Important Rules Acceptance

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/vsf-default/blob/master/CONTRIBUTING.md)